### PR TITLE
Fixed a bug when tags contained slash

### DIFF
--- a/git-export-diff.rb
+++ b/git-export-diff.rb
@@ -78,7 +78,7 @@ else
   desc = %x[git describe --contains --all #{sha}]
   name = case desc
     when /^tags/
-      desc[/tags\/(\w+)\^0/, 1].strip
+      desc[/tags\/([\w\/]+)\^0/, 1].strip
     when /^remotes/
       desc[/remotes\/(\w+\/\w+)/, 1].gsub("/", "-").strip + "-#{sha[0,7]}"
     else


### PR DESCRIPTION
操作対象のtagsに「/」が含まれていると下記のエラーになるので修正しました。
> `<main>': undefined method `strip' for nil:NilClass (NoMethodError)